### PR TITLE
feat: Allow to call BuildAndWriteFilesList on non-copied embedded dirs

### DIFF
--- a/embed_util/embedded_files.go
+++ b/embed_util/embedded_files.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 type EmbeddedFiles struct {
@@ -129,7 +128,7 @@ func (e *EmbeddedFiles) copyEmbeddedFilesToTmp(embedFs fs.FS, fl *fileList) erro
 			if resolvedFle.Mode.Type() == existingSt.Mode().Type() {
 				if resolvedFle.Mode.IsDir() {
 					continue
-				} else if existingSt.Size() == resolvedFle.Size && existingSt.ModTime().Unix() == resolvedFle.ModTime {
+				} else if existingSt.Size() == resolvedFle.Size {
 					// unchanged
 					continue
 				}
@@ -176,12 +175,6 @@ func (e *EmbeddedFiles) copyEmbeddedFilesToTmp(embedFs fs.FS, fl *fileList) erro
 		err = os.WriteFile(path, data, resolvedFle.Mode.Perm())
 		if err != nil {
 			return err
-		}
-		if !resolvedFle.Mode.IsDir() {
-			err = os.Chtimes(path, time.Time{}, time.Unix(resolvedFle.ModTime, 0))
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/embed_util/file_list.go
+++ b/embed_util/file_list.go
@@ -20,7 +20,6 @@ type fileList struct {
 type fileListEntry struct {
 	Name       string      `json:"name"`
 	Size       int64       `json:"size"`
-	ModTime    int64       `json:"modTime"`
 	Mode       fs.FileMode `json:"perm"`
 	Symlink    string      `json:"symlink,omitempty"`
 	Compressed bool        `json:"compressed,omitempty"`
@@ -49,10 +48,9 @@ func buildFileListFromDir(dir string) (*fileList, error) {
 		}
 
 		fle := fileListEntry{
-			Name:    relPath,
-			Size:    info.Size(),
-			ModTime: info.ModTime().Unix(),
-			Mode:    info.Mode(),
+			Name: relPath,
+			Size: info.Size(),
+			Mode: info.Mode(),
 		}
 
 		if info.Mode().Type() == fs.ModeSymlink {
@@ -94,17 +92,15 @@ func buildFileListFromFs(embedFs fs.FS) (*fileList, error) {
 		}
 
 		fle := fileListEntry{
-			Name:    path,
-			Size:    info.Size(),
-			ModTime: info.ModTime().Unix(),
-			Mode:    info.Mode() | 0o600,
+			Name: path,
+			Size: info.Size(),
+			Mode: info.Mode() | 0o600,
 		}
 
 		if info.Mode().Type() == fs.ModeSymlink {
 			return fmt.Errorf("symlink not supported in buildFileListFromFs")
 		} else if info.Mode().IsDir() {
 			fle.Size = 0
-			fle.ModTime = 0
 		}
 
 		fl.Files = append(fl.Files, fle)

--- a/embed_util/file_list.go
+++ b/embed_util/file_list.go
@@ -43,7 +43,7 @@ func buildFileListFromDir(dir string) (*fileList, error) {
 			return err
 		}
 
-		if relPath == "." {
+		if relPath == "." || relPath == "files.json" {
 			return nil
 		}
 
@@ -82,7 +82,7 @@ func buildFileListFromFs(embedFs fs.FS) (*fileList, error) {
 	var fl fileList
 
 	err := fs.WalkDir(embedFs, ".", func(path string, d fs.DirEntry, err error) error {
-		if path == "." {
+		if path == "." || path == "files.json" {
 			return nil
 		}
 


### PR DESCRIPTION
This also reverts the mod-time fix from before. It turned out that pip installed packages do not preserve mod times.