### PR TITLE
fix: make `CreateEmbeddedPipPackagesForKnownPlatforms` work with windows paths

### DIFF
--- a/embed_util/embedded_files.go
+++ b/embed_util/embedded_files.go
@@ -152,8 +152,10 @@ func (e *EmbeddedFiles) copyEmbeddedFilesToTmp(embedFs fs.FS, fl *fileList) erro
 
 		var data []byte
 
+		fleName := filepath.ToSlash(resolvedFle.Name)
+
 		if resolvedFle.Compressed {
-			data, err = fs.ReadFile(embedFs, resolvedFle.Name+".gz")
+			data, err = fs.ReadFile(embedFs, fleName+".gz")
 			if err != nil {
 				return err
 			}
@@ -167,7 +169,7 @@ func (e *EmbeddedFiles) copyEmbeddedFilesToTmp(embedFs fs.FS, fl *fileList) erro
 				return err
 			}
 		} else {
-			data, err = fs.ReadFile(embedFs, resolvedFle.Name)
+			data, err = fs.ReadFile(embedFs, fleName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR fixes #19 

`files.json` (the file generated by `doWriteFilesList()`) stores platform-native paths to python packages. On Windows, the stored paths would be separated by backslashes, e.g. `PIL\\BdfFontFile.py`.

The stored paths are used directly by [fs.ReadFile](https://pkg.go.dev/io/fs#ReadFile). `fs.ReadFile` is unconventional in that the paths MUST BE forward slashed regardless of the OS its ran on. From the [io/fs docs](https://pkg.go.dev/io/fs#ValidPath):
> Note that paths are slash-separated on all systems, even Windows. Paths containing other characters such as backslash and colon are accepted as valid, but those characters must never be interpreted by an [FS](https://pkg.go.dev/io/fs#FS) implementation as path element separators

This PR converts the backslashes in the path to forward slashes right before calling `fs.ReadFile`. It does not change how the paths in `files.json` are stored.