### PR TITLE
Fix for Windows codegen

### DIFF
--- a/embed_util/file_list.go
+++ b/embed_util/file_list.go
@@ -48,7 +48,7 @@ func buildFileListFromDir(dir string) (*fileList, error) {
 		}
 
 		fle := fileListEntry{
-			Name: relPath,
+			Name: filepath.ToSlash(relPath), // Fix for Windows, for an fs.FS, you should open files with forward slashes
 			Size: info.Size(),
 			Mode: info.Mode(),
 		}
@@ -92,7 +92,7 @@ func buildFileListFromFs(embedFs fs.FS) (*fileList, error) {
 		}
 
 		fle := fileListEntry{
-			Name: path,
+			Name: filepath.ToSlash(path), // Fix for Windows, for an fs.FS, you should open files with forward slashes
 			Size: info.Size(),
 			Mode: info.Mode() | 0o600,
 		}


### PR DESCRIPTION
On windows, when pip installing dependencies, the paths in the `files.json` file are stored with backslashes, for example:
`"_distutils_hack\\__init__.py"`. This causes issues when copying the embedded filesystem to the temp directory. It is not allowed to open an embedded file using a "Windows path", this for example: `fs.ReadFile(embedFs, "_distutils_hack\\__init__.py")`. 

A minimal example to reproduce the issue:

generate/main.go 
```go
package main

import (
	"log"
	"os"
	"strings"

	"github.com/kluctl/go-embed-python/pip"
)

const deps = `
setuptools==75.8.0
`

func main() {
	platforms := map[string][]string{
		"darwin-arm64":  {"macosx_11_0_arm64", "macosx_12_0_arm64"}, // No problems here
		"windows-amd64": {"win_amd64"},                              // Here the backslashes appear in files.json                                               
	}
	reqs := tempReqs(deps)

	for goPlatform, pipPlatforms := range platforms {
		s := strings.Split(goPlatform, "-")
		goOs, goArch := s[0], s[1]
		err := pip.CreateEmbeddedPipPackages(reqs, goOs, goArch, pipPlatforms, "data")
		if err != nil {
			log.Fatal(err)
		}
	}
}

func tempReqs(data string) string {
	f, err := os.CreateTemp(os.TempDir(), "*-requirements.txt")
	if err != nil {
		log.Fatal(err)
	}
	defer f.Close()
	if _, err := f.Write([]byte(data)); err != nil {
		log.Fatal(err)
	}

	return f.Name()
}

```

main.go
```go
package main

import (
	"log"

	"github.com/kluctl/go-embed-python/embed_util"
	"gitlab.com/floriaanpost/go-embed-bug-reproduce/data"
)

//go:generate go run generate/main.go

func main() {
	_, err := embed_util.NewEmbeddedFiles(data.Data, "testdeps")
	if err != nil {
		log.Fatal(err)
	}
}
```

Then init, generate and run:
```bash
go mod init github.com/floriaanpost/go-embed-bug-reproduce
go mod tidy
go generate
go run main.go
```